### PR TITLE
feat: Add Live TV feature

### DIFF
--- a/config.json
+++ b/config.json
@@ -85,5 +85,37 @@
       "api": "https://zy.xmm.hk/api.php/provide/vod",
       "name": "小猫咪资源"
     }
-  }
+  },
+  "live_tv": [
+    {
+      "name": "CCTV-1 综合",
+      "logo": "https://live.fanmingming.com/tv/CCTV1.png",
+      "url": "https://live.fanmingming.com/tv/CCTV1.m3u8"
+    },
+    {
+      "name": "CCTV-2 财经",
+      "logo": "https://live.fanmingming.com/tv/CCTV2.png",
+      "url": "https://live.fanmingming.com/tv/CCTV2.m3u8"
+    },
+    {
+      "name": "CCTV-3 综艺",
+      "logo": "https://live.fanmingming.com/tv/CCTV3.png",
+      "url": "https://live.fanmingming.com/tv/CCTV3.m3u8"
+    },
+    {
+      "name": "CCTV-4 中文国际",
+      "logo": "https://live.fanmingming.com/tv/CCTV4.png",
+      "url": "https://live.fanmingming.com/tv/CCTV4.m3u8"
+    },
+    {
+      "name": "CCTV-5 体育",
+      "logo": "https://live.fanmingming.com/tv/CCTV5.png",
+      "url": "https://live.fanmingming.com/tv/CCTV5.m3u8"
+    },
+    {
+      "name": "CCTV-6 电影",
+      "logo": "https://live.fanmingming.com/tv/CCTV6.png",
+      "url": "https://live.fanmingming.com/tv/CCTV6.m3u8"
+    }
+  ]
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,7 +57,8 @@ export default async function RootLayout({
       name: 'name' in category ? category.name : '',
       type: category.type,
       query: category.query,
-    })) || ([] as Array<{ name: string; type: 'movie' | 'tv'; query: string }>);
+    })) || ([] as Array<{ name:string; type: 'movie' | 'tv'; query: string }>);
+  let liveTvChannels = (RuntimeConfig as any).live_tv || [];
   if (
     process.env.NEXT_PUBLIC_STORAGE_TYPE !== 'd1' &&
     process.env.NEXT_PUBLIC_STORAGE_TYPE !== 'upstash'
@@ -76,6 +77,7 @@ export default async function RootLayout({
       type: category.type,
       query: category.query,
     }));
+    liveTvChannels = config.live_tv || [];
   }
 
   // 将运行时配置注入到全局 window 对象，供客户端在运行时读取
@@ -86,6 +88,7 @@ export default async function RootLayout({
     DOUBAN_PROXY: doubanProxy,
     DISABLE_YELLOW_FILTER: disableYellowFilter,
     CUSTOM_CATEGORIES: customCategories,
+    LIVE_TV_CHANNELS: liveTvChannels,
   };
 
   return (

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import PageLayout from '@/components/PageLayout';
+import LivePlayer from '@/components/LivePlayer'; // Import the new player component
+
+// Define the type for a single Live TV channel
+interface LiveTvChannel {
+  name: string;
+  logo: string;
+  url: string;
+}
+
+const LiveTVPage = () => {
+  const [channels, setChannels] = useState<LiveTvChannel[]>([]);
+  const [currentChannel, setCurrentChannel] = useState<LiveTvChannel | null>(null);
+
+  useEffect(() => {
+    const runtimeConfig = (window as any).RUNTIME_CONFIG || {};
+    const liveTvChannels = runtimeConfig.LIVE_TV_CHANNELS || [];
+    setChannels(liveTvChannels);
+    if (liveTvChannels.length > 0) {
+      setCurrentChannel(liveTvChannels[0]);
+    }
+  }, []);
+
+  return (
+    <PageLayout>
+      <div className="flex flex-col md:flex-row md:h-[calc(100vh-80px)]">
+        {/* Channel List */}
+        <div className="w-full md:w-64 lg:w-72 xl:w-80 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700/50 flex-shrink-0">
+          <div className="p-4 border-b border-gray-200 dark:border-gray-700/50">
+            <h2 className="text-xl font-bold text-gray-800 dark:text-gray-200">电视直播</h2>
+          </div>
+          <ul className="overflow-y-auto h-full p-2">
+            {channels.map((channel) => (
+              <li
+                key={channel.name}
+                className={`flex items-center p-3 cursor-pointer rounded-lg transition-colors duration-200 ${
+                  currentChannel?.url === channel.url
+                    ? 'bg-green-500/20 text-green-700 dark:bg-green-500/10 dark:text-green-400 font-semibold'
+                    : 'hover:bg-gray-100/50 dark:hover:bg-gray-800/50'
+                }`}
+                onClick={() => setCurrentChannel(channel)}
+              >
+                <img src={channel.logo} alt={channel.name} className="w-10 h-6 object-contain mr-3" />
+                <span className="text-sm">{channel.name}</span>
+              </li>
+            ))}
+            {channels.length === 0 && (
+              <div className="text-center text-gray-500 py-8">
+                没有可用的直播频道。
+              </div>
+            )}
+          </ul>
+        </div>
+
+        {/* Video Player */}
+        <div className="flex-1 bg-black h-64 md:h-auto">
+          {currentChannel ? (
+            <LivePlayer url={currentChannel.url} name={currentChannel.name} />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-white bg-gray-800">
+              <p className="text-lg">请从左侧选择一个频道进行播放</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </PageLayout>
+  );
+};
+
+export default LiveTVPage;

--- a/src/components/LivePlayer.tsx
+++ b/src/components/LivePlayer.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Artplayer from 'artplayer';
+import Hls from 'hls.js';
+import { useEffect, useRef } from 'react';
+
+interface LivePlayerProps {
+  url: string;
+  name: string;
+}
+
+// Extend HTMLVideoElement to support hls property
+declare global {
+  interface HTMLVideoElement {
+    hls?: Hls;
+  }
+}
+
+const LivePlayer = ({ url, name }: LivePlayerProps) => {
+  const artRef = useRef<HTMLDivElement>(null);
+  const artPlayerRef = useRef<Artplayer | null>(null);
+
+  useEffect(() => {
+    if (!artRef.current) return;
+
+    // Destroy previous instance if it exists
+    if (artPlayerRef.current) {
+      artPlayerRef.current.destroy(true);
+    }
+
+    const player = new Artplayer({
+      container: artRef.current,
+      url: url,
+      title: name,
+      isLive: true,
+      autoplay: true,
+      muted: false,
+      pip: true,
+      setting: true,
+      fullscreen: true,
+      fullscreenWeb: true,
+      playsInline: true,
+      theme: '#22c55e',
+      lang: 'zh-cn',
+      hotkey: false,
+      moreVideoAttr: {
+        crossOrigin: 'anonymous',
+      },
+      customType: {
+        m3u8: function (video: HTMLVideoElement, url: string) {
+          if (Hls.isSupported()) {
+            if (video.hls) {
+              video.hls.destroy();
+            }
+            const hls = new Hls();
+            hls.loadSource(url);
+            hls.attachMedia(video);
+            video.hls = hls;
+          } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+            video.src = url;
+          }
+        },
+      },
+      icons: {
+        loading: '<img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MCIgaGVpZ2h0PSI1MCIgdmlld0JveD0iMCAwIDUwIDUwIj48cGF0aCBkPSJNMjUuMjUxIDYuNDYxYy0xMC4zMTggMC0xOC42ODMgOC4zNjUtMTguNjgzIDE4LjY4M2g0LjA2OGMwLTguMDcgNi4zNDUtMTQuNjE1IDE0LjYxNS0xNC42MTVWNi40NjF6IiBmaWxsPSIjMDA5Njg4Ij48YW5pbWF0ZVRyYW5zZm9ybSBhdHRyaWJ1dGVOYW1lPSJ0cmFuc2Zvcm0iIGF0dHJpYnV0ZVR5cGU9IlhNTCIgZHVyPSIxcyIgZnJvbT0iMCAyNSAyNSIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIHRvPSIzNjAgMjUgMjUiIHR5cGU9InJvdGF0ZSIvPjwvcGF0aD48L3N2Zz4=">',
+      },
+    });
+
+    artPlayerRef.current = player;
+
+    return () => {
+      if (artPlayerRef.current) {
+        artPlayerRef.current.destroy(true);
+      }
+    };
+  }, [url, name]);
+
+  return <div ref={artRef} style={{ width: '100%', height: '100%' }} />;
+};
+
+export default LivePlayer;

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { Clover, Film, Home, Search, Star, Tv } from 'lucide-react';
+import { Clover, Film, Home, Search, Star, Tv, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -37,6 +37,11 @@ const MobileBottomNav = ({ activePath }: MobileBottomNavProps) => {
       icon: Clover,
       label: '综艺',
       href: '/douban?type=show',
+    },
+    {
+      icon: Radio,
+      label: '电视直播',
+      href: '/live',
     },
   ]);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { Clover, Film, Home, Menu, Search, Star, Tv } from 'lucide-react';
+import { Clover, Film, Home, Menu, Search, Star, Tv, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
@@ -139,6 +139,11 @@ const Sidebar = ({ onToggle, activePath = '/' }: SidebarProps) => {
       icon: Clover,
       label: '综艺',
       href: '/douban?type=show',
+    },
+    {
+      icon: Radio,
+      label: '电视直播',
+      href: '/live',
     },
   ]);
 


### PR DESCRIPTION
This commit introduces a new Live TV streaming feature to the application.

- Adds a "Live TV" section to the navigation (sidebar and mobile).
- Creates a new page at `/live` to host the feature.
- Implements a channel list that is configurable via `config.json`.
- Includes a dedicated `LivePlayer` component using ArtPlayer and HLS.js to play live streams.
- Populates `config.json` with example CCTV channel sources.

NOTE: I was unable to fully test this feature by running the application due to a persistent environment issue. A `pre-commit` hook fails with a `pnpm: not found` error, which blocked me from starting the development server. The code has been implemented based on the project's existing structure and best practices, but it should be tested in a working environment.