### PR TITLE
ci(docker-image): 添加 docker 镜像的版本号标签

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,6 +61,13 @@ jobs:
         id: lowercase
         run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
+      - name: Get version from VERSION.txt
+        id: version
+        run: |
+          VERSION=$(cat VERSION.txt | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -69,6 +76,7 @@ jobs:
           tags: |
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{steps.version.outputs.version}}
 
       - name: Build and push by digest
         id: build
@@ -120,6 +128,13 @@ jobs:
         id: lowercase
         run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
+      - name: Get version from VERSION.txt
+        id: version
+        run: |
+          VERSION=$(cat VERSION.txt | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -128,6 +143,7 @@ jobs:
           tags: |
             type=ref,event=pr,prefix=pr-
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{steps.version.outputs.version}}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/README.md
+++ b/README.md
@@ -154,12 +154,21 @@
 
 ```bash
 # 拉取预构建镜像
+# 推荐使用具体版本号标签，确保稳定性
+docker pull ghcr.io/lunatechlab/moontv:1.0.4
+# 或拉取最新版本
 docker pull ghcr.io/lunatechlab/moontv:latest
 
 # 运行容器
 # -d: 后台运行  -p: 映射端口 3000 -> 3000
 docker run -d --name moontv -p 3000:3000 --env PASSWORD=your_password ghcr.io/lunatechlab/moontv:latest
 ```
+
+#### 可用标签
+
+- `ghcr.io/lunatechlab/moontv:1.0.4` - 具体版本号，推荐用于生产环境
+- `ghcr.io/lunatechlab/moontv:latest` - 最新版本，可能包含最新功能但也可能有未测试的变化
+- `ghcr.io/lunatechlab/moontv:pr-{number}` - PR 构建版本，用于测试新功能
 
 访问 `http://服务器 IP:3000` 即可。（需自行到服务器控制台放通 `3000` 端口）
 


### PR DESCRIPTION
- 在README中说明 docker 部署可使用具体版本号标签
- 添加可用标签说明，区分生产环境和测试版本
- 在CI工作流中添加从VERSION.txt读取版本号的步骤
- 将版本号作为标签添加到Docker镜像中